### PR TITLE
Update fishing spot link to Teamcraft

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
         </td>
         <!-- Location -->
         <td>
-          <i class="location-button map icon"></i> <a href="https://garlandtools.org/db/#{{?it.data.location.spearfishing}}node{{??}}fishing{{?}}/{{=it.data.location.id}}"
+          <i class="location-button map icon"></i> <a href="https://ffxivteamcraft.com/db/en/{{?it.data.location.spearfishing}}spearfishing{{??}}fishing{{?}}-spot/{{=it.data.location.id}}"
              target="cp_gt" class="location-name">{{=it.data.location.name}}</a><br/>
           <span style="font-size: smaller" class="zone-name">{{=it.data.location.zoneName}}</span>
         </td>


### PR DESCRIPTION
This change updates the fishing spot link to point to Teamcraft, which provides a lot of useful information over Garland Tools.

https://ffxivteamcraft.com/db/en/fishing-spot/216 vs https://garlandtools.org/db/#fishing/216

I ran into permissions issues when initializing the repo, so I wasn't able to test this personally, but I hope it's a small enough change that you don't mind giving it a look.