### PR TITLE
Reuse upcoming windows modal (fixes #105)

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -220,13 +220,24 @@ body.dark #fish-eyes-button.link.item.active:hover .sprite-icon-status-fish_eyes
   grid-template-columns: 3fr 1fr 1fr;
   grid-row-gap: 0.2rem;
   grid-column-gap: 1rem;
+  grid-template-rows: auto repeat(10, auto);
 }
 
 .upcoming-windows-grid .header {
   border-bottom: thin black solid;
+  font-weight: bold;
 }
 .inverted .upcoming-windows-grid .header {
   border-bottom: thin white solid;
+}
+
+.upcoming-windows-grid .window-start {
+  font-weight: bold;
+}
+.upcoming-windows-grid .window-start,
+.upcoming-windows-grid .window-duration,
+.upcoming-windows-grid .window-downtime {
+  white-space: nowrap;
 }
 
 .location-button:hover {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
     <link rel="stylesheet" href="public/images/sprite.css?5.55_20210525" />
     <link rel="stylesheet" href="css/semantic_ui_overrides.css?20201207_2149" />
-    <link rel="stylesheet" href="css/overlay.css?20210701_1904" />
+    <link rel="stylesheet" href="css/overlay.css?20210824_2130" />
     <link rel="stylesheet" href="css/dark_overlay.css?20200229_1723" />
 
     <!-- Localization Support script -->
@@ -414,13 +414,13 @@
             <b>Downtime</b>
           </div>
           {{~it.availability.upcomingWindows :nextWindow:idx}}
-            <div style="white-space: nowrap;">
-              <b>{{=moment(nextWindow.start).calendar()}}</b>
+            <div class="window-start">
+              {{=moment(nextWindow.start).calendar()}}
             </div>
-            <div style="white-space: nowrap;">
+            <div class="window-duration">
               {{=nextWindow.duration}}
             </div>
-            <div style="white-space: nowrap;">
+            <div class="window-downtime">
               {{=nextWindow.downtime}}
             </div>
           {{~}}
@@ -429,11 +429,11 @@
     </script>
 
     <!-- At last, we can load the layout and view model code. -->
-    <script type="text/javascript" src="js/app/layout.js?20201207_1933"></script>
+    <script type="text/javascript" src="js/app/layout.js?20210824_2130"></script>
     <script type="text/javascript" src="js/app/fishguide.js?20201111_1232"></script>
     <script type="text/javascript" src="js/app/map.js?20201031_2321"></script>
     <!-- NOTE: The ViewModel should be the last script loaded. -->
-    <script type="text/javascript" src="js/app/viewmodel.js?20210701_2121"></script>
+    <script type="text/javascript" src="js/app/viewmodel.js?20210824_2130"></script>
 
     <script type="text/javascript">
       $(() => {
@@ -747,6 +747,9 @@
           </div>
         </div>
       </div>
+
+      <!-- Modal for displaying upcoming windows -->
+      <div id="upcoming-windows" class="ui longer flushed modal upcoming-windows"></div>
 
       <!-- Display the list of fish -->
       <div id="fish-table-container">

--- a/js/app/layout.js
+++ b/js/app/layout.js
@@ -160,10 +160,11 @@ class FishTableLayout {
         .attr('data-tooltip', moment(fishEntry.availability.upcoming.date).calendar())
         .text(fishEntry.availability.upcoming.downtime);
       
-      // If this fish has upcoming windows data, update it now.
-      if (fishEntry.upcomingWindowsPopupElement !== null) {
-        $(fishEntry.upcomingWindowsPopupElement).modal('hide');
-        $(fishEntry.upcomingWindowsPopupElement).empty().append(
+      // If this fish is currently being displayed in the upcoming windows, update it now!
+      if (ViewModel.upcomingWindowsEntry === fishEntry) {
+        // Update it in real-time. Just re-run the template after clearing... it's not a
+        // lot of data, so it should hopefully process quickly.
+        ViewModel.$upcomingWindows.empty().append(
           this.templates.upcomingWindows(fishEntry));
       }
 

--- a/js/app/viewmodel.js
+++ b/js/app/viewmodel.js
@@ -382,9 +382,9 @@ let ViewModel = new class {
 
     // Save the upcoming windows element.
     this.$upcomingWindows = $('#upcoming-windows');
-    // this.$upcomingWindows.modal({
-    //   onHide: this.onHideUpcomingWindows
-    // });
+    this.$upcomingWindows.modal({
+      onHide: this.onHideUpcomingWindows
+    });
 
     // Apply theme to elements now.
     // DO NOT ADD ANY MORE UI ELEMENTS AFTER THIS LINE OR THEY WILL
@@ -773,7 +773,6 @@ let ViewModel = new class {
 
     // Now we can display the modal. If it wasn't already initialized, this should
     // take can of that too.
-    this.$upcomingWindows.modal('setting', 'onHide', this.onHideUpcomingWindows)
     this.$upcomingWindows.modal('show');
     console.timeEnd("Display upcoming windows");
   }


### PR DESCRIPTION
Instead of having a modal for every single fish entry, just have one and fill in the contents when the user clicks on the icon.

Initial load time was reduced by 65% while typical time to display the information appears unchanged.