### PR TITLE
Add button to window time that will display in game /alarm command to…

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -215,6 +215,10 @@ body.dark #fish-eyes-button.link.item.active:hover .sprite-icon-status-fish_eyes
   cursor: pointer;
 }
 
+.alarm-cmd-button:hover {
+  cursor: pointer;
+}
+
 .upcoming-windows-grid {
   display: grid;
   grid-template-columns: 3fr 1fr 1fr;

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
               {{?}}
             {{?}}
           {{??}}
-            <i class="wait icon"></i>&nbsp;
+            <i class="alarm-cmd-button wait icon"></i>&nbsp;
             {{? it.data.startHour === 0 && it.data.endHour === 24}}
               All Day
             {{??}}
@@ -342,7 +342,7 @@
               {{?}}
             {{?}}
           {{??}}
-            <i class="wait icon"></i>&nbsp;
+            <i class="alarm-cmd-button wait icon"></i>&nbsp;
             {{? it.data.startHour === 0 && it.data.endHour === 24}}
               All Day
             {{??}}
@@ -619,6 +619,25 @@
           <div id="export-settings-upload" class="ui labeled icon disabled button">
             <i class="cloud upload icon"></i>
             Upload
+          </div>
+        </div>
+      </div>
+
+      <!-- Modal for copying alarm command -->
+      <div id="alarm-cmd-modal" class="ui tiny modal">
+        <div class="header">In-game Alarm command</div>
+        <div class="content">
+          <div class="ui form">
+            <p>Copy the command below and execute in-game.</p>
+            <div class="field">
+              <textarea rows="8" id="alarm-cmd-data" style="font-family: monospace;"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="actions">
+          <div id="alarm-cmd-copy" class="ui labeled icon button" data-clipboard-target="#alarm-cmd-data">
+            <i class="copy icon"></i>
+            Copy
           </div>
         </div>
       </div>

--- a/js/app/viewmodel.js
+++ b/js/app/viewmodel.js
@@ -452,6 +452,7 @@ let ViewModel = new class {
     // Initialize import/export modals.
     $('#export-settings-modal').modal();
     $('#import-settings-modal').modal();
+    $('#alarm-cmd-modal').modal();
 
     // Special event handlers.
     // These are mainly supporting the SemanticUI widgets.
@@ -755,6 +756,32 @@ let ViewModel = new class {
     return false;
   }
 
+  displayAlarmCommand(entry) {
+    let clipboard = new ClipboardJS('#alarm-cmd-copy', {
+      container: document.getElementById('alarm-cmd-modal')
+    });
+    clipboard.on('success', function(e) {
+      console.info("Command copied to clipboard.");
+      e.clearSelection();
+    });
+    clipboard.on('error', function(e) {
+      console.error("Failed to copy command");
+    });
+    // eg /alarm "アラームaaaaaa" et 0500 6 (max 10 chars)
+    const fourDigitEoTime = ('0' + (entry.data.startHour | 0)).slice(-2) + ('0' + (60*(entry.data.startHour % 1) | 0)).slice(-2)
+    $('#alarm-cmd-data').text('/alarm "' + entry.data.name.substring(0,10) + '" et ' + fourDigitEoTime + ' 3');
+    // Display the modal.
+    $('#alarm-cmd-modal')
+      .modal({
+        onHidden: function() {
+          // Clean up the clipboard DOM.
+          clipboard.destroy();
+        }
+      })
+      .modal('show');
+  }
+
+
   displayUpcomingWindows(entry) {
     console.time("Display upcoming windows");
     // If for some reason, the modal is already showing, we should hide it first.
@@ -862,6 +889,12 @@ let ViewModel = new class {
       console.info("Displaying upcoming windows for %s", fish.name);
       this.displayUpcomingWindows(entry);
     });
+
+    $('.alarm-cmd-button', $entry).on('click', e => {
+      console.info("Displaying in-game alarm command for %s", fish.name);
+      this.displayAlarmCommand(entry);
+    });
+    
 
     // Connect location button.
     $('.location-button', $entry).on('click', this.onFishEntryShowLocationClicked);


### PR DESCRIPTION
Lately, I have been catching up on my Big Fish log and utilizing both this tool (love it by the way, so useful) and TC.   Oftentimes, I've done my prep before a window, around 20-30 minutes before, and then switch my focus to something else and then miss the window.   I know that TC alarms could help me here, but since I usually just need these once, it felt like it didn't quite fit to create one there to be used once and then delete it (which requires a few steps I think).   

As a stopgap, I'm using the in-game /alarm command, because it makes a loud enough noise and goes away after use.

This PR utilizes existing modal code to make this just a tad easier for me, by clicking on the small clock icon next to the fishes time restriction, a modal appears with the text for the in-game alarm command with a Copy button:

![image](https://user-images.githubusercontent.com/6663484/133836210-80c18c97-0bc5-43d3-b1a5-6b7ce623610b.png)

![image](https://user-images.githubusercontent.com/6663484/133836233-dc091109-f851-4376-98f6-60dde95cd864.png)


It is a very small thing, but it seemed useful enough to me to code up quickly, if you think anyone else might find it useful (and can't think of any harm it may be to add), feel free to incorporate.

Love this tool and appreciate the hard work to keep it updated!

oku