### PR TITLE
(fixes #150) detect inituition fish availability changes

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -350,11 +350,6 @@ body.dark #fishes thead tr th {
   pointer-events: none;
 }
 
-/* Prevent displaying the availability while the list is pending resort. */
-tr.fish-entry.fish-availability-transitioning .fish-availability-current {
-  filter: opacity(0); /* still needs to take up space, just not be visible */
-}
-
 /*
  * These rules match the Intuition status requirement when a duration is present.
  * CSS4 would allow us to use :has(> span) instead... but it's not ready yet :(

--- a/js/app/layout.js
+++ b/js/app/layout.js
@@ -143,7 +143,7 @@ class FishTableLayout {
     // First, check if the fish's availability changed.
     // YES, you still want to do this because of Fish Eyes.
     if (fishEntry.isCatchable != $fishEntry.hasClass('fish-active')) {
-      $fishEntry.toggleClass('fish-active').addClass('fish-availability-transitioning');
+      $fishEntry.toggleClass('fish-active');
       console.debug(`${fishEntry.id} "${fishEntry.data.name}" has changed availability.`);
       hasFishAvailabilityChanged = true;
     }
@@ -305,9 +305,6 @@ class FishTableLayout {
 
       this.append(entry);
     }
-
-    // Remove the 'fish-availability-transitioning' class after sorting!
-    $('.fish-entry', this.fishTable).removeClass('fish-availability-transitioning');
 
     console.timeEnd('Sorting');
   }

--- a/js/app/layout.js
+++ b/js/app/layout.js
@@ -215,8 +215,10 @@ class FishTableLayout {
 
     // Update any intuition fish rows as well!
     for (let subEntry of fishEntry.intuitionEntries) {
-      if (!subEntry.data.alwaysAvailable)
-        this.update(subEntry, baseTime, needsFullUpdate);
+      if (!subEntry.data.alwaysAvailable) {
+        let changed = this.update(subEntry, baseTime, needsFullUpdate);
+        hasFishAvailabilityChanged ||= changed;
+      }
     }
 
     // Let the caller know this fish changed availability or bins.

--- a/js/app/layout.js
+++ b/js/app/layout.js
@@ -215,10 +215,8 @@ class FishTableLayout {
 
     // Update any intuition fish rows as well!
     for (let subEntry of fishEntry.intuitionEntries) {
-      if (!subEntry.data.alwaysAvailable) {
-        let changed = this.update(subEntry, baseTime, needsFullUpdate);
-        hasFishAvailabilityChanged ||= changed;
-      }
+      if (!subEntry.data.alwaysAvailable)
+        this.update(subEntry, baseTime, needsFullUpdate);
     }
 
     // Let the caller know this fish changed availability or bins.


### PR DESCRIPTION
When the layout updates subEntries (intuition fish) it does not capture whether the subEntry availability has changed. This means intuition fish availability changes don't provoke a layout sort. Without a layout sort the "fish-availability-transitioning" class won't get removed, so the text for the time remaining remains set of 0 opacity.

~~This PR "hoists" availability changes from intuition fish up into the parent fish entry which *should* provoke a call to `this.layout.sort` from the view model. I'm not sure if this is the best fix but it seems to work in the dev environment.~~

Since we don't want to force an expensive sort, and the `fish-availability-transitioning` class was not functioning correctly this PR removes the class and associated logic and style(s) to fix the issue (#150) with intuition fish countdowns disappearing.