### PR TITLE
Make it easier to click the checkbox in fishing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 __pycache__
 *.pyc
 pyvirt/
+.venv
 
 # NPM
 node_modules/

--- a/css/overlay.css
+++ b/css/overlay.css
@@ -603,10 +603,10 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   width: 3em;
   border-color: rgba(232, 232, 232, 0.20);
   /* 
-    The triangle can be slightly hard to get your mouse to
-    110% allows the users a bit easier time hitting it
+   * The triangle can be slightly hard to get your mouse to
+   * 115% allows the users a bit easier time hitting it
    */
-  clip-path: polygon(0 0, 110% 0, 0 110%);
+  clip-path: polygon(0 0, 115% 0, 0 115%);
 }
 .fish-guide .fish-entry .ui.left.corner.label.hovering {
   border-color: rgba(232, 232, 232, 0.50);

--- a/css/overlay.css
+++ b/css/overlay.css
@@ -602,11 +602,10 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   height: 3em;
   width: 3em;
   border-color: rgba(232, 232, 232, 0.20);
-  /* Clip the corner label to its triangle so the WHOLE visible triangle is the
-     hover/click target (the 110% pushes the hit edge slightly past the visible
-     wedge for forgiving clicks). The clipped-away lower-right half passes clicks
-     through to the fish-entry, so the rest of the tile still selects the fish.
-     The mark/hover handler is bound to this label in fishguide.js. */
+  /* 
+    The triangle can be slightly hard to get your mouse to
+    110% allows the users a bit easier time hitting it
+   */
   clip-path: polygon(0 0, 110% 0, 0 110%);
 }
 .fish-guide .fish-entry .ui.left.corner.label.hovering {

--- a/css/overlay.css
+++ b/css/overlay.css
@@ -584,7 +584,7 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   position: relative;
 }
 .fish-guide .fish-entry:not(.disabled),
-.fish-guide .fish-entry:not(.disabled) .ui.left.corner.label .icon {
+.fish-guide .fish-entry:not(.disabled) .ui.left.corner.label {
   cursor: pointer;
 }
 .fish-guide .fish-entry.selected {
@@ -602,6 +602,12 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   height: 3em;
   width: 3em;
   border-color: rgba(232, 232, 232, 0.20);
+  /* Clip the corner label to its triangle so the WHOLE visible triangle is the
+     hover/click target (the 110% pushes the hit edge slightly past the visible
+     wedge for forgiving clicks). The clipped-away lower-right half passes clicks
+     through to the fish-entry, so the rest of the tile still selects the fish.
+     The mark/hover handler is bound to this label in fishguide.js. */
+  clip-path: polygon(0 0, 110% 0, 0 110%);
 }
 .fish-guide .fish-entry .ui.left.corner.label.hovering {
   border-color: rgba(232, 232, 232, 0.50);

--- a/css/overlay.css
+++ b/css/overlay.css
@@ -584,7 +584,7 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   position: relative;
 }
 .fish-guide .fish-entry:not(.disabled),
-.fish-guide .fish-entry:not(.disabled) .ui.left.corner.label {
+.fish-guide .fish-entry:not(.disabled) .ui.left.corner.label .icon {
   cursor: pointer;
 }
 .fish-guide .fish-entry.selected {

--- a/js/app/fishguide.js
+++ b/js/app/fishguide.js
@@ -111,19 +111,19 @@ let FishGuide = function(){
         self.displayFishGuidePage(newPage);
       });
 
-      $('.label .icon', this.fishGridEntries$).on({
+      $('.ui.left.corner.label', this.fishGridEntries$).on({
         mouseenter: function() {
-          $(this).parents('.fish-entry .label').addClass('hovering');
+          $(this).addClass('hovering');
         },
         mouseleave: function() {
-          $(this).parents('.fish-entry .label').removeClass('hovering');
+          $(this).removeClass('hovering');
         },
         click: function() {
           // Okay, this gets tricky because if the fish isn't displayed, it's
           // more complicated. Either way, we need to update the ViewModel's
           // settings at a minimum...
           // TODO: The completion list really needs to be a set...
-          self.toggleFishCaughtState($(this).parents('.fish-entry'));
+          self.toggleFishCaughtState($(this).closest('.fish-entry'));
         }
       });
 


### PR DESCRIPTION
# Changes
- added `.venv` to .gitignore. hope this is ok, it's just the standard virtual environment name these days and my tooling for python all rely on this.
- moves the "clickable" part of the triangle up to the triangle itself instead of the checkbox
- gives the triangle a slightly larger footprint (with clip-path) than just the triangle itself, meaning it highlights and is click-able 15% outside it's normal size (only extends into the icon, not outside). This makes hitting the triangle a tiny bit easier.

This makes the fishing guide slightly easier to use and a lot fewer miss clicks when using it.
Have other ideas but thought I'd start with a small thing :)