### PR TITLE
Tag all fish on page

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -584,10 +584,6 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   gap: 0.5em;
   margin-top: 0.75em;
 }
-/*
- * Two standalone buttons: drop Fomantic's default right margin so `gap`
- * controls spacing and the group sits flush with the grid's right edge.
- */
 .fish-guide .fish-grid-out .fish-guide-bulk-actions .ui.button {
   margin: 0;
 }

--- a/css/overlay.css
+++ b/css/overlay.css
@@ -578,6 +578,19 @@ tr.fishtrain-fishentrydetails .sprite-icon-status-intuition.has-duration > span 
   grid-gap: 2px;
   grid-template-columns: repeat(10, max-content);
 }
+.fish-guide .fish-grid-out .fish-guide-bulk-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+  margin-top: 0.75em;
+}
+/*
+ * Two standalone buttons: drop Fomantic's default right margin so `gap`
+ * controls spacing and the group sits flush with the grid's right edge.
+ */
+.fish-guide .fish-grid-out .fish-guide-bulk-actions .ui.button {
+  margin: 0;
+}
 .fish-guide .fish-entry {
   height: 46px;
   width: 46px;

--- a/fishtrain.html
+++ b/fishtrain.html
@@ -38,7 +38,7 @@
 
     <link rel="stylesheet" href="public/images/sprite.css?7.5_20260428_1005" />
     <link rel="stylesheet" href="css/semantic_ui_overrides.css?20250805_0942" />
-    <link rel="stylesheet" href="css/overlay.css?20260622_1407" />
+    <link rel="stylesheet" href="css/overlay.css?20260624_2008" />
     <link rel="stylesheet" href="css/dark_overlay.css?20260414_2133" />
 
     <style>

--- a/fishtrain.html
+++ b/fishtrain.html
@@ -38,7 +38,7 @@
 
     <link rel="stylesheet" href="public/images/sprite.css?7.5_20260428_1005" />
     <link rel="stylesheet" href="css/semantic_ui_overrides.css?20250805_0942" />
-    <link rel="stylesheet" href="css/overlay.css?20260624_2008" />
+    <link rel="stylesheet" href="css/overlay.css?20260624_2020" />
     <link rel="stylesheet" href="css/dark_overlay.css?20260414_2133" />
 
     <style>

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
 
     <!-- At last, we can load the layout and view model code. -->
     <script type="text/javascript" src="js/app/layout.js?20260107_2306"></script>
-    <script type="text/javascript" src="js/app/fishguide.js?20260624_2002"></script>
+    <script type="text/javascript" src="js/app/fishguide.js?20260624_2027"></script>
     <script type="text/javascript" src="js/app/baittally.js?20251111_1551"></script>
     <script type="text/javascript" src="js/app/map.js?20250310_2300"></script>
     <!-- NOTE: The ViewModel should be the last script loaded. -->

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
 
     <!-- At last, we can load the layout and view model code. -->
     <script type="text/javascript" src="js/app/layout.js?20260107_2306"></script>
-    <script type="text/javascript" src="js/app/fishguide.js?20260624_2051"></script>
+    <script type="text/javascript" src="js/app/fishguide.js?20260624_2056"></script>
     <script type="text/javascript" src="js/app/baittally.js?20251111_1551"></script>
     <script type="text/javascript" src="js/app/map.js?20250310_2300"></script>
     <!-- NOTE: The ViewModel should be the last script loaded. -->

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
     <link rel="stylesheet" href="public/images/sprite.css?7.5_20260428_1005" />
     <link rel="stylesheet" href="css/semantic_ui_overrides.css?20250805_0942" />
-    <link rel="stylesheet" href="css/overlay.css?20260622_1407" />
+    <link rel="stylesheet" href="css/overlay.css?20260624_2008" />
     <link rel="stylesheet" href="css/dark_overlay.css?20260414_2133" />
 
     <script type="text/javascript" src="js/app/checkForUpdates.js?20221001_1235"></script>
@@ -408,7 +408,7 @@
 
     <!-- At last, we can load the layout and view model code. -->
     <script type="text/javascript" src="js/app/layout.js?20260107_2306"></script>
-    <script type="text/javascript" src="js/app/fishguide.js?20260622_1407"></script>
+    <script type="text/javascript" src="js/app/fishguide.js?20260624_2002"></script>
     <script type="text/javascript" src="js/app/baittally.js?20251111_1551"></script>
     <script type="text/javascript" src="js/app/map.js?20250310_2300"></script>
     <!-- NOTE: The ViewModel should be the last script loaded. -->

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
 
     <!-- At last, we can load the layout and view model code. -->
     <script type="text/javascript" src="js/app/layout.js?20260107_2306"></script>
-    <script type="text/javascript" src="js/app/fishguide.js?20260624_2048"></script>
+    <script type="text/javascript" src="js/app/fishguide.js?20260624_2051"></script>
     <script type="text/javascript" src="js/app/baittally.js?20251111_1551"></script>
     <script type="text/javascript" src="js/app/map.js?20250310_2300"></script>
     <!-- NOTE: The ViewModel should be the last script loaded. -->

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
 
     <!-- At last, we can load the layout and view model code. -->
     <script type="text/javascript" src="js/app/layout.js?20260107_2306"></script>
-    <script type="text/javascript" src="js/app/fishguide.js?20260624_2027"></script>
+    <script type="text/javascript" src="js/app/fishguide.js?20260624_2048"></script>
     <script type="text/javascript" src="js/app/baittally.js?20251111_1551"></script>
     <script type="text/javascript" src="js/app/map.js?20250310_2300"></script>
     <!-- NOTE: The ViewModel should be the last script loaded. -->

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
     <link rel="stylesheet" href="public/images/sprite.css?7.5_20260428_1005" />
     <link rel="stylesheet" href="css/semantic_ui_overrides.css?20250805_0942" />
-    <link rel="stylesheet" href="css/overlay.css?20260624_2008" />
+    <link rel="stylesheet" href="css/overlay.css?20260624_2020" />
     <link rel="stylesheet" href="css/dark_overlay.css?20260414_2133" />
 
     <script type="text/javascript" src="js/app/checkForUpdates.js?20221001_1235"></script>

--- a/js/app/fishguide.js
+++ b/js/app/fishguide.js
@@ -274,7 +274,8 @@ let FishGuide = function(){
       // Deselect the current fish, and fixup other properties.
       this.fishGridEntries$.removeClass('selected')
                            .addClass('disabled')
-                           .removeClass('caught');
+                           .removeClass('caught')
+                           .removeAttr('data-tooltip');
       this.fishInfo$.addClass('hidden');
       // This resets the icons since they are controlled by unique style classes.
       $('.fish-icon', this.fishGridEntries$).attr('class', 'fish-icon sprite-icon');
@@ -286,6 +287,7 @@ let FishGuide = function(){
         $(this.fishGridEntries$[i]).data('fishInfo', fishInfosForPage[i])
                                    .removeClass('disabled')
                                    .toggleClass('caught', ViewModel.isFishCaught(fishInfosForPage[i].id))
+                                   .attr('data-tooltip', __p(fishInfosForPage[i], 'name'))
                                    .children('.fish-icon').addClass('sprite-icon-fish_n_tackle-' + fishInfosForPage[i].icon);
       }
     }

--- a/js/app/fishguide.js
+++ b/js/app/fishguide.js
@@ -350,7 +350,6 @@ let FishGuide = function(){
       this.fishGridEntries$.filter(':not(.disabled)').each(function(idx, elem) {
         let entry$ = $(elem);
         let fishInfo = entry$.data('fishInfo');
-        if (fishInfo === undefined) return;
 
         if (isCaught) {
           ViewModel.settings.completed.add(fishInfo.id);

--- a/js/app/fishguide.js
+++ b/js/app/fishguide.js
@@ -54,8 +54,8 @@ let FishGuide = function(){
 
     // Bulk actions for the current page.
     bulkActions: `<div class="fish-guide-bulk-actions">
-  <div class="ui mini compact button" id="fishGuideMarkAll">Mark all</div>
-  <div class="ui mini compact button" id="fishGuideUnmarkAll">Unmark all</div>
+  <div class="ui mini compact green button" id="fishGuideMarkAll">Mark page as caught</div>
+  <div class="ui mini compact button" id="fishGuideUnmarkAll">Unmark page</div>
 </div>`
   };
 

--- a/js/app/fishguide.js
+++ b/js/app/fishguide.js
@@ -50,6 +50,12 @@ let FishGuide = function(){
   <div class="fish-meta">
     <!-- TODO: Include things like, when is it up next, bait, etc. -->
   </div>
+</div>`,
+
+    // Bulk actions for the current page.
+    bulkActions: `<div class="fish-guide-bulk-actions">
+  <div class="ui mini compact button" id="fishGuideMarkAll">Mark all</div>
+  <div class="ui mini compact button" id="fishGuideUnmarkAll">Unmark all</div>
 </div>`
   };
 
@@ -57,6 +63,7 @@ let FishGuide = function(){
   {{#def.pageSelector}}
   <div class="fish-grid-out">
     {{#def.fishGrid}}
+    {{#def.bulkActions}}
   </div>
   {{#def.fishInfo}}
 </div>`;
@@ -155,6 +162,16 @@ let FishGuide = function(){
         // Deselect the current fish.
         self.fishGridEntries$.removeClass('selected');
         self.fishInfo$.addClass('hidden');
+      });
+
+      // Bulk caught-state actions for the current page.
+      $('#fishGuideMarkAll', elem).on('click', function(e) {
+        e.stopPropagation();
+        self.setAllFishCaughtOnPage(true);
+      });
+      $('#fishGuideUnmarkAll', elem).on('click', function(e) {
+        e.stopPropagation();
+        self.setAllFishCaughtOnPage(false);
       });
 
       // Finally, initialize the menu selector by "displaying" the first page.
@@ -326,6 +343,34 @@ let FishGuide = function(){
 
       // Toggle the visible check mark.
       fishEntry$.toggleClass('caught');
+    }
+
+    setAllFishCaughtOnPage(isCaught) {
+      // Only the entries belonging to the current page are :not(.disabled).
+      this.fishGridEntries$.filter(':not(.disabled)').each(function(idx, elem) {
+        let entry$ = $(elem);
+        let fishInfo = entry$.data('fishInfo');
+        if (fishInfo === undefined) return;
+
+        if (isCaught) {
+          ViewModel.settings.completed.add(fishInfo.id);
+        } else {
+          ViewModel.settings.completed.delete(fishInfo.id);
+        }
+
+        // Keep the main-list entry in sync if this fish is currently tracked.
+        let fishEntry = ViewModel.fishEntries[fishInfo.id];
+        if (fishEntry !== undefined && fishEntry.isCaught !== isCaught) {
+          fishEntry.isCaught = isCaught;
+          ViewModel.layout.updateCaughtState(fishEntry);
+        }
+
+        entry$.toggleClass('caught', isCaught);
+      });
+
+      // Persist + re-render once for the whole page.
+      ViewModel.saveSettings();
+      ViewModel.updateDisplay();
     }
 
     preShowHandler() {

--- a/js/app/fishguide.js
+++ b/js/app/fishguide.js
@@ -54,8 +54,8 @@ let FishGuide = function(){
 
     // Bulk actions for the current page.
     bulkActions: `<div class="fish-guide-bulk-actions">
-  <div class="ui mini compact green button" id="fishGuideMarkAll">Mark page as caught</div>
-  <div class="ui mini compact button" id="fishGuideUnmarkAll">Unmark page</div>
+  <div class="ui mini compact green button" id="fishGuideMarkAll" data-tooltip="This can not be reverted! Do not click unless sure!">Mark page as caught</div>
+  <div class="ui mini compact button" id="fishGuideUnmarkAll" data-tooltip="This can not be reverted! Do not click unless sure!">Unmark page</div>
 </div>`
   };
 
@@ -367,7 +367,6 @@ let FishGuide = function(){
         entry$.toggleClass('caught', isCaught);
       });
 
-      // Persist + re-render once for the whole page.
       ViewModel.saveSettings();
       ViewModel.updateDisplay();
     }

--- a/private/updateCacheBusters.py
+++ b/private/updateCacheBusters.py
@@ -22,7 +22,7 @@ def _update_cache_busters(assets=[], patch=None, all=False, timestamp=None):
         timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M')
 
     JS_ASSET_PAT = re.compile(r'<script type="text/javascript" src="/?([^?]+)\?([^"]+)"></script>')
-    CSS_ASSET_PAT = re.compile(r'<link rel="stylesheet" href="/?([^?]+)?([^"]+)"\s*/>')
+    CSS_ASSET_PAT = re.compile(r'<link rel="stylesheet" href="/?([^?]+)\?([^"]+)"\s*/>')
 
     for page in PAGES:
         output = ''

--- a/private/updateCacheBusters.py
+++ b/private/updateCacheBusters.py
@@ -22,7 +22,7 @@ def _update_cache_busters(assets=[], patch=None, all=False, timestamp=None):
         timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M')
 
     JS_ASSET_PAT = re.compile(r'<script type="text/javascript" src="/?([^?]+)\?([^"]+)"></script>')
-    CSS_ASSET_PAT = re.compile(r'<link ref="stylesheet" href="/?([^?]+)?([^"]+)"\s*/>')
+    CSS_ASSET_PAT = re.compile(r'<link rel="stylesheet" href="/?([^?]+)?([^"]+)"\s*/>')
 
     for page in PAGES:
         output = ''

--- a/trainpass/index.html
+++ b/trainpass/index.html
@@ -34,7 +34,7 @@
 
     <link rel="stylesheet" href="/public/images/sprite.css?7.5_20260428_1005" />
     <link rel="stylesheet" href="/css/semantic_ui_overrides.css?20250805_0942" />
-    <link rel="stylesheet" href="/css/overlay.css?20260624_2008" />
+    <link rel="stylesheet" href="/css/overlay.css?20260624_2020" />
     <link rel="stylesheet" href="/css/dark_overlay.css?20260414_2133" />
 
     <style type="text/css">

--- a/trainpass/index.html
+++ b/trainpass/index.html
@@ -34,7 +34,7 @@
 
     <link rel="stylesheet" href="/public/images/sprite.css?7.5_20260428_1005" />
     <link rel="stylesheet" href="/css/semantic_ui_overrides.css?20250805_0942" />
-    <link rel="stylesheet" href="/css/overlay.css?20260622_1407" />
+    <link rel="stylesheet" href="/css/overlay.css?20260624_2008" />
     <link rel="stylesheet" href="/css/dark_overlay.css?20260414_2133" />
 
     <style type="text/css">


### PR DESCRIPTION
## Changes

- adds two buttons, `Mark page as caught` and `Unmark page`
  - clicking `Mark` just marks all the fish on the page as caught
  - clicking `Unmark` does the opposite
  - buttons have mouse hover text that `THIS IS NOT REVERSABLE` 
- fixed the updateCacheBuster.py script that was looking for `<link ref=` instead of `<link rel=` and regexp for it was not matching "cache buster" stuff correctly.
- since I was fiddling with the fishing guide anyway took the opportunity to add hover text over the grid, small issue that very long names of fish at the left most column will have their names clipped, but still quite useful to me :)


<img width="541" height="616" alt="image" src="https://github.com/user-attachments/assets/be99512a-9cbb-48ab-84d9-2f30d935c35f" />
